### PR TITLE
Generalizing the text of the HTML

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,7 +104,7 @@
             for="data-usage-agreement-keep-private"
           >
             I consent to this data being used for fine-tuning future Pygmalion
-            models, as long as it's kept private and not manually reviewed by humans.
+            models, as long as it's kept private and not manually reviewed by trusted PygmalionAI members.
           </label>
         </div>
         <div class="form-check mb-3">
@@ -122,7 +122,7 @@
             for="data-usage-agreement-can-be-public"
           >
             I consent to this data being used for fine-tuning future Pygmalion
-            models, AND to having it be included in the public dataset alongside it being potentially manually reviewed by humans.
+            models, AND to having it potentially be included in a public dataset alongside being manually reviewed by trusted PygmalionAI members.
           </label>
         </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -104,7 +104,7 @@
             for="data-usage-agreement-keep-private"
           >
             I consent to this data being used for fine-tuning future Pygmalion
-            models, as long as it's kept private and not manually reviewed by trusted PygmalionAI members.
+            models, as long as it's kept private and not looked at by anyone.
           </label>
         </div>
         <div class="form-check mb-3">

--- a/public/index.html
+++ b/public/index.html
@@ -28,13 +28,13 @@
       }
     </style>
 
-    <title>CAI Dump Uploader</title>
+    <title>Conversational Dump Uploader</title>
   </head>
   <body class="parent-container">
     <main class="m-auto w-100 form-signin" style="max-width: 500px">
-      <h3>CAI Dump Uploader</h3>
+      <h3>Conversational Dump Uploader</h3>
       <p>
-        Please use the form below to contribute your CharacterAI dumps to the
+        Please use the form below to contribute your conversation logs to the
         project.
       </p>
 
@@ -104,7 +104,7 @@
             for="data-usage-agreement-keep-private"
           >
             I consent to this data being used for fine-tuning future Pygmalion
-            models, as long as it's kept private.
+            models, as long as it's kept private and not manually reviewed by humans.
           </label>
         </div>
         <div class="form-check mb-3">
@@ -122,7 +122,7 @@
             for="data-usage-agreement-can-be-public"
           >
             I consent to this data being used for fine-tuning future Pygmalion
-            models, AND to having it be included in the public dataset.
+            models, AND to having it be included in the public dataset alongside it being potentially manually reviewed by humans.
           </label>
         </div>
 
@@ -138,7 +138,7 @@
         personal information. We don't want any of that.
       </p>
       <p>
-        If your dumps were generated with a version older than v1.2 of the
+        If your CAI dumps were generated with a version older than v1.2 of the
         userscript, they may contain your CAI display name. In that case, please
         update and create new dumps.
       </p>

--- a/public/result/index.html
+++ b/public/result/index.html
@@ -44,11 +44,11 @@
       });
     </script>
 
-    <title>CAI Dump Uploader</title>
+    <title>Conversational Dump Uploader</title>
   </head>
   <body class="parent-container">
     <main class="m-auto w-100 form-signin" style="max-width: 500px">
-      <h3>CAI Dump Uploader</h3>
+      <h3>Conversational Dump Uploader</h3>
 
       <hr />
 


### PR DESCRIPTION
Now that users can choose to either donate CAI or Claude logs, it makes no sense to have the title of this page be only "CAI Dump Uploader".